### PR TITLE
Prevent "(MISSING)" in printed out differences

### DIFF
--- a/teq.go
+++ b/teq.go
@@ -35,7 +35,7 @@ func (teq Teq) Equal(t TestingT, expected, actual any) bool {
 	}()
 	ok := teq.equal(expected, actual)
 	if !ok {
-		t.Errorf(teq.report(expected, actual))
+		t.Error(teq.report(expected, actual))
 	}
 	return ok
 }


### PR DESCRIPTION
This fix prevents unintended "(MISSING)" phrases in printed out differences due to incorrect interpretation of them as a text to be formatted.

**Steps to recreate:**
```go
func Test1(t *testing.T) {
  // this assert fails as expected but the output is contaminated by the phrase "(MISSING)"
  teq.New().Equal(t, "expected text", "actual %20 text")
}
``` 

**Expected output:**
```
example_test.go:25: not equal
        differences:
        --- expected
        +++ actual
        @@ -1 +1 @@
        -"expected text"
        +"actual %20 text"
--- FAIL: Test1 (0.00s)
```

**Actual output:**
```
example_test.go:25: not equal
        differences:
        --- expected
        +++ actual
        @@ -1 +1 @@
        -"expected text"
        +"actual %! (MISSING)text"
--- FAIL: Test1 (0.00s)
```